### PR TITLE
Fix: initTracer bug + call span.finish in reply hook.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ Require the plugin and register it within Fastify, the pass the following option
 
 *exposeAPI: (true by default)* Exposes the Span API, binded to the current request, which allows the user to setTags, and log the current span.
 
-This plugins supports all other options and configurations of the official [jaeger-client-node](https://github.com/jaegertracing/jaeger-client-node) throught the options object of the plugin.
+This plugins supports all options and configurations of [jaeger-client-node's `initTracer` method](https://github.com/jaegertracing/jaeger-client-node#initialization).
+
+- The options param can be configured via `opts.initTracerOpts`
+- All other top-level `opts` will be passed in as the config param.
 
 It uses the logger set to the fastify instance as the tracer logger.
 
@@ -33,7 +36,7 @@ fastify.get('/', (req, reply) => {
 
 fastify.listen(3000, err => {
   if (err) throw err
-  console.log('Server listenting on localhost:', fastify.server.address().port)
+  console.log('Server listening on localhost:', fastify.server.address().port)
 })
 ```
 

--- a/index.js
+++ b/index.js
@@ -62,9 +62,9 @@ function jaegerPlugin (fastify, opts, next) {
   function onRequest (req, res, done) {
     const parentSpanContext = tracer.extract(FORMAT_HTTP_HEADERS, setContext(req.raw.headers))
     const span = tracer.startSpan(`${req.raw.method} - ${url.format(req.raw.url)}`, {
-        childOf: parentSpanContext,
-        tags: { [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_SERVER, [Tags.HTTP_METHOD]: req.raw.method, [Tags.HTTP_URL]: url.format(req.raw.url) }
-      })
+      childOf: parentSpanContext,
+      tags: { [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_SERVER, [Tags.HTTP_METHOD]: req.raw.method, [Tags.HTTP_URL]: url.format(req.raw.url) }
+    })
 
     tracerMap.set(req, span)
     done()

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -31,90 +31,86 @@ test('Should not expose jaeger api when explicitly set to false', async ({ teard
   is(fastify.hasRequestDecorator('jaeger'), false)
 })
 
-test('Should initialize plugin with correct configuration', async (child) => {
-  const serviceName = 'test'
-
-  const setupChildTest = (pluginOpts) => {
-    const clear = () => {
-      delete require.cache[require.resolve('jaeger-client')]
-      delete require.cache[require.resolve(require('path').join(__dirname, '../index'))]
-    }
-
-    clear()
-    require('jaeger-client')
-    const initTracerSpy = spy(require.cache[require.resolve('jaeger-client')].exports.initTracer)
-    require.cache[require.resolve('jaeger-client')].exports.initTracer = initTracerSpy
-
-    const fastify = createFastify()
-    fastify.get('/', (req, reply) => {
-      reply.code(200).send({ hello: 'world' })
-    })
-
-    fastify.register(require('../index'), pluginOpts)
-
-    return {
-      fastify,
-      initTracerSpy,
-      teardown: async () => {
-        clear()
-        await fastify.close()
-      }
-    }
+const setupTracerTest = (pluginOpts) => {
+  const clear = () => {
+    delete require.cache[require.resolve('jaeger-client')]
+    delete require.cache[require.resolve(require('path').join(__dirname, '../index'))]
   }
 
-  child.test('should use default config when no configuration is provided', async (ct) => {
-    const { fastify, initTracerSpy, teardown } = setupChildTest({ serviceName })
+  clear()
+  require('jaeger-client')
+  const initTracerSpy = spy(require.cache[require.resolve('jaeger-client')].exports.initTracer)
+  require.cache[require.resolve('jaeger-client')].exports.initTracer = initTracerSpy
 
-    ct.teardown(teardown)
-
-    await fastify.ready()
-    const response = await fastify.inject({ method: 'GET', url: '/' })
-
-    ct.is(initTracerSpy.spy.calls.length, 1)
-    ct.has(initTracerSpy.spy.calls[0][0], {
-      serviceName: 'test',
-      sampler: { type: 'const', param: 1 },
-      reporter: { logSpans: false },
-    })
-    ct.has(initTracerSpy.spy.calls[0][1], { logger: fastify.log })
-    ct.is(fastify.hasRequestDecorator('jaeger'), true)
-    ct.is(response.statusCode, 200)
+  const fastify = createFastify()
+  fastify.get('/', (req, reply) => {
+    reply.code(200).send({ hello: 'world' })
   })
 
-  child.test('should merge default config with the user provided config', async (ct) => {
-    const { fastify, initTracerSpy, teardown } = setupChildTest({
-      serviceName,
-      reporter: {
-        logSpans: true
-      },
-      initTracerOpts: {
-        tags: {
-          foo: 'bar'
-        }
-      }
-    })
+  fastify.register(require('../index'), pluginOpts)
 
-    ct.teardown(teardown)
+  return {
+    fastify,
+    initTracerSpy,
+    teardownCb: async () => {
+      clear()
+      await fastify.close()
+    }
+  }
+}
 
-    await fastify.ready()
-    const response = await fastify.inject({ method: 'GET', url: '/' })
+test('should use default config when no configuration is provided', async ({ teardown, is, has }) => {
+  const { fastify, initTracerSpy, teardownCb } = setupTracerTest({ serviceName: 'test' })
 
-    ct.is(initTracerSpy.spy.calls.length, 1)
-    ct.has(initTracerSpy.spy.calls[0][0], {
-      serviceName: 'test',
-      sampler: { type: 'const', param: 1 },
-      reporter: { logSpans: true },
-    })
-    ct.has(initTracerSpy.spy.calls[0][1], {
-      logger: fastify.log,
+  teardown(teardownCb)
+
+  await fastify.ready()
+  const response = await fastify.inject({ method: 'GET', url: '/' })
+
+  is(initTracerSpy.spy.calls.length, 1)
+  has(initTracerSpy.spy.calls[0][0], {
+    serviceName: 'test',
+    sampler: { type: 'const', param: 1 },
+    reporter: { logSpans: false }
+  })
+  has(initTracerSpy.spy.calls[0][1], { logger: fastify.log })
+  is(fastify.hasRequestDecorator('jaeger'), true)
+  is(response.statusCode, 200)
+})
+
+test('should merge default config with the user provided config', async ({ teardown, is, has }) => {
+  const { fastify, initTracerSpy, teardownCb } = setupTracerTest({
+    serviceName: 'test',
+    reporter: {
+      logSpans: true
+    },
+    initTracerOpts: {
       tags: {
         foo: 'bar'
       }
-    })
-    ct.has(initTracerSpy.spy.results[0].value, { _tags: { foo: 'bar' } })
-    ct.is(fastify.hasRequestDecorator('jaeger'), true)
-    ct.is(response.statusCode, 200)
+    }
   })
+
+  teardown(teardownCb)
+
+  await fastify.ready()
+  const response = await fastify.inject({ method: 'GET', url: '/' })
+
+  is(initTracerSpy.spy.calls.length, 1)
+  has(initTracerSpy.spy.calls[0][0], {
+    serviceName: 'test',
+    sampler: { type: 'const', param: 1 },
+    reporter: { logSpans: true }
+  })
+  has(initTracerSpy.spy.calls[0][1], {
+    logger: fastify.log,
+    tags: {
+      foo: 'bar'
+    }
+  })
+  has(initTracerSpy.spy.results[0].value, { _tags: { foo: 'bar' } })
+  is(fastify.hasRequestDecorator('jaeger'), true)
+  is(response.statusCode, 200)
 })
 
 test('Should set proper tag values', async ({ teardown, same }) => {


### PR DESCRIPTION
### Summary
###### Call `span.finish()` in reply hook.
   Spans were being created, but never completed and therefore weren't reporting.

###### Separate the params being passed to `initTracer`
   `initTracer` receives a [`config`](https://github.com/jaegertracing/jaeger-client-node/blob/4dd7b3e8d2282241e8be55203331c13eb8208028/src/configuration.js#L29) and an [`options`](https://github.com/jaegertracing/jaeger-client-node/blob/4dd7b3e8d2282241e8be55203331c13eb8208028/src/configuration.js#L188) param each of which are objects that can contain a `reporter` and `throttler` key. However, each param expects a different value under those keys. 

   Since `tracerDefaults` containted `opts` and was being spread into both `config` and `options` params, any `opts` containing the `reporter` or `throttler` key would cause the plugin to crash (`"TypeError: this._reporter.setProcess is not a function"`)

Now anything meant to be passed into the `options` param of `initTracer` can be passed via `opts.initTracerOpts`

### Test Plan
I have created a branch in [this fork](https://github.com/autotelic/fastify-jaeger) called `config-bug-test` to prove the existence of the `initTracer` bug. Just clone the repo, checkout the branch, and run `npm test`. The test should fail with `"TypeError: this._reporter.setProcess is not a function"` being thrown.