### PR TITLE
Replace reply.res.statusCode with reply.statusCode

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ function jaegerPlugin (fastify, opts, next) {
 
   function onResponse (req, reply, done) {
     const span = tracerMap.get(req)
-    span.setTag(Tags.HTTP_STATUS_CODE, reply.res.statusCode)
+    span.setTag(Tags.HTTP_STATUS_CODE, reply.statusCode)
     span.finish()
     done()
   }

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ function jaegerPlugin (fastify, opts, next) {
 
   function onResponse (req, reply, done) {
     const span = tracerMap.get(req)
-    span.setTag(Tags.HTTP_STATUS_CODE, reply.statusCode)
+    span.setTag(Tags.HTTP_STATUS_CODE, reply.raw.statusCode)
     span.finish()
     done()
   }


### PR DESCRIPTION
Fixes #2 

See the Fastify [V3 Migration Guide](https://github.com/fastify/fastify/blob/main/docs/Migration-Guide-V3.md) and the actual PR that implemented the change: https://github.com/fastify/fastify/pull/2008