### PR TITLE
Improve typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,16 +1,11 @@
-import {Span} from 'opentracing';
-import {FastifyPluginCallback} from 'fastify'
+import { Span } from 'opentracing'
+import { FastifyPluginCallback } from 'fastify'
+import { TracingConfig, TracingOptions } from 'jaeger-client'
 
-interface PluginOptions {
-    serviceName?: string,
-    reporter?: {
-        logSpans?: boolean
-    }
+interface PluginOptions extends TracingConfig {
     exposeAPI?: boolean,
     state?: never,
-    initTracerOpts?: never,
-
-    [key: string]: unknown;
+    initTracerOpts?: TracingOptions,
 }
 
 declare module 'fastify' {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
   },
   "homepage": "https://github.com/maumercado/fastify-jaeger#readme",
   "devDependencies": {
+    "@types/jaeger-client": "^3.18.1",
     "@types/node": "^15.3.0",
-    "fastify": "^2.13.0",
+    "fastify": "^3.18.1",
     "snazzy": "^8.0.0",
     "standard": "^14.3.3",
     "tap": "^14.10.7",


### PR DESCRIPTION
Current typings is very minimal and even disallow to set jaeger host (without using `any` casting).
This PR use types already defined in `@types/jaeger-client` to improve typings of `fastify-jaeger`.